### PR TITLE
Uppercase Start() in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AtlantisForProxyman.Net is a dotnet binding to the fantastic [Atlantis library f
 
    ```
    #if DEBUG
-   Atlantis.start()
+   Atlantis.Start()
    #endif
    ```
 


### PR DESCRIPTION
Fix Start() Typo in README (Uppercase) :)